### PR TITLE
Fix beetle-lib package version

### DIFF
--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -49,7 +49,7 @@
     "@ngrx/effects": "^6.0.1",
     "@ngrx/store": "^6.0.1",
     "@ngrx/store-devtools": "^6.0.1",
-    "@teiid/beetle-lib": "~0.0.10",
+    "@teiid/beetle-lib": "~0.0.0",
     "@types/moment": "^2.13.0",
     "angular-tree-component": "^7.1.0",
     "angular2-text-mask": "^9.0.0",


### PR DESCRIPTION
Changes the specified beetle-lib version.  Semantic versioning for 0.0.x is handled a little differently.  I verified that this is actually picking up the latest version...